### PR TITLE
add case unsensitive to already processed header

### DIFF
--- a/main/src/main/java/org/apache/james/jdkim/DKIMCommon.java
+++ b/main/src/main/java/org/apache/james/jdkim/DKIMCommon.java
@@ -30,6 +30,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public abstract class DKIMCommon {
@@ -80,7 +81,7 @@ public abstract class DKIMCommon {
             // NOTE check this getter is case insensitive
             List<String> hl = h.getFields(header.toString());
             if (hl != null && hl.size() > 0) {
-                Integer done = processedHeader.get(header.toString().toLowerCase());
+                Integer done = processedHeader.get(header.toString().toLowerCase(Locale.ENGLISH));
                 if (done == null)
                     done = 0;
                 int doneHeaders = done + 1;
@@ -88,7 +89,7 @@ public abstract class DKIMCommon {
                     String fv = hl.get(hl.size() - doneHeaders);
                     updateSignature(signature, relaxedHeaders, header, fv);
                     signature.update("\r\n".getBytes());
-                    processedHeader.put(header.toString().toLowerCase(), doneHeaders);
+                    processedHeader.put(header.toString().toLowerCase(Locale.ENGLISH), doneHeaders);
                 }
             }
         }

--- a/main/src/main/java/org/apache/james/jdkim/DKIMCommon.java
+++ b/main/src/main/java/org/apache/james/jdkim/DKIMCommon.java
@@ -80,7 +80,7 @@ public abstract class DKIMCommon {
             // NOTE check this getter is case insensitive
             List<String> hl = h.getFields(header.toString());
             if (hl != null && hl.size() > 0) {
-                Integer done = processedHeader.get(header.toString());
+                Integer done = processedHeader.get(header.toString().toLowerCase());
                 if (done == null)
                     done = 0;
                 int doneHeaders = done + 1;
@@ -88,7 +88,7 @@ public abstract class DKIMCommon {
                     String fv = hl.get(hl.size() - doneHeaders);
                     updateSignature(signature, relaxedHeaders, header, fv);
                     signature.update("\r\n".getBytes());
-                    processedHeader.put(header.toString(), doneHeaders);
+                    processedHeader.put(header.toString().toLowerCase(), doneHeaders);
                 }
             }
         }

--- a/main/src/test/java/org/apache/james/jdkim/FileBasedTest.java
+++ b/main/src/test/java/org/apache/james/jdkim/FileBasedTest.java
@@ -203,6 +203,10 @@ public class FileBasedTest extends TestCase {
                 "pmta",
                 "myspace.com",
                 "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQChRebhcm4h8BkIYHRxg1GlKLsDkwdrqkFJ8f88xHQ5Gf3NH4I4e06M3XQ+B4tWWK/rX0srwXFgrJPzKZK+x7gN89nmqyM+NNaM+Wm2C0GjTpx6639zK3bAAGYCm0L9lGD7PgDxpWok+YogH0Ml4acEwDw/cnhErAWAnX8doPliawIDAQAB");
+        pkr.addRecord(
+                "mail",
+                "sqli.com",
+                "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC1CTqmkuRWkxlHcv1peAz3c0RuXHthVO1xx1Hy4HryZUJwSJo/R3cnEwKorQvlRuDSMgXSLLxI8u6n7h6mzRmHdsS/A+pKc7nx/6WS4N6U57PSNqOclxfwa27m/EIL6KTk9KDhaKsXxquQUBkP1CQEUZHPhQ/t7s4dmU/kvGFgNQIDAQAB");
 
         try {
             List<SignatureRecord> res = new DKIMVerifier(pkr).verify(is);

--- a/main/src/test/resources/org/apache/james/jdkim/corpus/multiHeader.eml
+++ b/main/src/test/resources/org/apache/james/jdkim/corpus/multiHeader.eml
@@ -1,0 +1,40 @@
+Received: from v4.mailinblack.org ([192.168.160.165])
+        by mib.mailinblack.com
+        with SMTP (SubEthaSMTP null) id J2VY6B21
+        for cballe@mailinblack.com;
+        Fri, 19 May 2017 16:35:35 +0200 (CEST)
+Received: from letsignit.sqli.com (letsignit.sqli.com [193.105.238.150])
+        (using TLSv1 with cipher ADH-AES256-SHA (256/256 bits))
+        (No client certificate requested)
+        by v4.mailinblack.org (Postfix) with ESMTPS id 26C07AC033
+        for <cballe@mailinblack.com>; Fri, 19 May 2017 16:35:35 +0200 (CEST)
+Received: from letsignit.sqli.com (localhost [127.0.0.1])
+        by letsignit.sqli.com (Postfix) with ESMTP id C107D580108
+        for <cballe@mailinblack.com>; Fri, 19 May 2017 16:35:34 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=sqli.com; s=mail;
+        t=1495204534; bh=7rIC1gdWBQp5oiCoqvFeWrl/plYm+72BA6KkoHkY0Y4=;
+        h=Date:To:From:subject:Subject:From;
+        b=fwEo9e/VyCdDggbuhLRBEbaCwcIx4x2GHlIpNA2phygpku50i86NnwBZhPNFAqAmI
+         GVA/JjW73Ealf3bANzKJl3FyHNAyThXfHzMZWYL6I9u+T5h8iFx07FvBaSyDMGtrW7
+         IBxEhFxzNwXcaBVMy/73N/VxPj+uZSy21MvzKWus=
+Received: from letsignit.sqli.com (localhost [127.0.0.1])
+        by localhost
+        with SMTP (LetSignIt ESMTP MAIL Service, Version: 1.0 ready at Fri May 19 16:35:34 CEST 2017) id A088A8AED87240C5BAF16CE0985D91EF
+        for cballe@mailinblack.com;
+        Fri, 19 May 2017 16:35:34 +0200 (CEST)
+Received: from letsignit.sqli.com (localhost [127.0.0.1])
+        by letsignit.sqli.com (Postfix) with ESMTP id B721D580108
+        for <cballe@mailinblack.com>; Fri, 19 May 2017 16:35:34 +0200 (CEST)
+inLsi: true
+inLsi: true
+Date: Thu, 18 May 2017 05:30:06 +0200
+To: support+warning@letsignit.com,cballe@mailinblack.com
+From: script@sqli.com
+subject: test Thu, 18 May 2017 05:30:06 +0200
+X-Mailer: swaks v20120320.0 jetmore.org/john/code/swaks/
+MIME-Version: 1.0
+Subject: letsignit.sqli.com 161 comptes crees -- OK
+Message-Id: <20170519143534.B721D580108@letsignit.sqli.com>
+
+Hello!
+This is a test email


### PR DESCRIPTION
Bug when header is  like "h=Date:To:From:Subject:subject:From;" with several same headers with different case and multiple value in header of email too. The Dkim check fail.
In this case, second "subject" was taking the first subject and not the second subject in header of email.