### PR TITLE
James-jdkim remove unused log4j

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -59,11 +59,6 @@
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mime4j-dom</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
         <dnsjava.version>3.4.1</dnsjava.version>
         <james-skin.version>1.8</james-skin.version>
         <junit.version>4.13.2</junit.version>
-        <log4j.version>2.14.1</log4j.version>
         <not-yet-commons-ssl.version>0.3.11</not-yet-commons-ssl.version>
         <target.jdk>1.8</target.jdk>
     </properties>
@@ -139,12 +138,6 @@
                 <version>${project.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <scope>runtime</scope>
-                <version>${log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
As discussed here: https://github.com/linagora/james-project/issues/4453

We should switch to slf4j instead of depending on a logging library implementation like log4j.

The weird thing is I do not need any refactoring following this change. James JDKIM likely does not use any logging since then?