### PR TITLE
[FIX] Shade the all commons-codec lib into jdkim

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -105,20 +105,6 @@
                                     <include>commons-codec:commons-codec</include>
                                 </includes>
                             </artifactSet>
-                            <filters>
-                                <filter>
-                                    <artifact>commons-codec:commons-codec</artifact>
-                                    <excludes>
-                                        <exclude>org/apache/commons/codec/String*</exclude>
-                                        <exclude>org/apache/commons/codec/language/*</exclude>
-                                        <exclude>org/apache/commons/codec/net/*</exclude>
-                                        <exclude>org/apache/commons/codec/digest/*</exclude>
-                                        <exclude>org/apache/commons/codec/binary/He*</exclude>
-                                        <exclude>org/apache/commons/codec/binary/Binary*</exclude>
-                                        <exclude>org/apache/commons/codec/binary/*Stream*</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.commons.codec</pattern>


### PR DESCRIPTION
Some issues were detected when running jdkim lib with other projects. After commons-codec upgrade, seems BinaryCodec is being used now for Base64 encoding, which was excluded from shading, as it was not the case before.

Shading the all commons-codec lib allows to avoid similar issues with future upgrades while still not forcing other projects to align their commons-codec version with jdkim.

cf ref => https://github.com/apache/james-project/pull/2672#issuecomment-2723843886