### PR TITLE
Store SignatureRecord in FailException

### DIFF
--- a/main/src/main/java/org/apache/james/jdkim/DKIMSigner.java
+++ b/main/src/main/java/org/apache/james/jdkim/DKIMSigner.java
@@ -121,12 +121,12 @@ public class DKIMSigner extends DKIMCommon {
 
             return "DKIM-Signature:" + bhj.getSignatureRecord().toString();
         } catch (InvalidKeyException e) {
-            throw new PermFailException("Invalid key: " + e.getMessage(), e);
+            throw new PermFailException("Invalid key: " + e.getMessage(), bhj.getSignatureRecord(), e);
         } catch (NoSuchAlgorithmException e) {
-            throw new PermFailException("Unknown algorythm: " + e.getMessage(),
+            throw new PermFailException("Unknown algorythm: " + e.getMessage(), bhj.getSignatureRecord(),
                     e);
         } catch (SignatureException e) {
-            throw new PermFailException("Signing exception: " + e.getMessage(),
+            throw new PermFailException("Signing exception: " + e.getMessage(), bhj.getSignatureRecord(),
                     e);
         }
     }

--- a/main/src/main/java/org/apache/james/jdkim/DKIMVerifier.java
+++ b/main/src/main/java/org/apache/james/jdkim/DKIMVerifier.java
@@ -119,27 +119,27 @@ public class DKIMVerifier extends DKIMCommon {
                     .matches()) {
                 throw new PermFailException("inapplicable key identity local="
                         + sign.getIdentityLocalPart() + " Pattern: "
-                        + pkr.getGranularityPattern().pattern(), sign.getIdentity().toString());
+                        + pkr.getGranularityPattern().pattern(), sign);
             }
 
             if (!pkr.isHashMethodSupported(sign.getHashMethod())) {
                 throw new PermFailException("inappropriate hash for a="
-                        + sign.getHashKeyType() + "/" + sign.getHashMethod(), sign.getIdentity().toString());
+                        + sign.getHashKeyType() + "/" + sign.getHashMethod(), sign);
             }
             if (!pkr.isKeyTypeSupported(sign.getHashKeyType())) {
                 throw new PermFailException("inappropriate key type for a="
-                        + sign.getHashKeyType() + "/" + sign.getHashMethod(), sign.getIdentity().toString());
+                        + sign.getHashKeyType() + "/" + sign.getHashMethod(), sign);
             }
 
             if (pkr.isDenySubdomains()) {
                 if (!sign.getIdentity().toString().toLowerCase().endsWith(
                         ("@" + sign.getDToken()).toLowerCase())) {
                     throw new PermFailException(
-                            "AUID in subdomain of SDID is not allowed by the public key record.", sign.getIdentity().toString());
+                            "AUID in subdomain of SDID is not allowed by the public key record.", sign);
                 }
             }
         } catch (IllegalStateException e) {
-            throw new PermFailException("Invalid public key: " + e.getMessage(), sign.getIdentity().toString());
+            throw new PermFailException("Invalid public key: " + e.getMessage(), sign);
         }
     }
 
@@ -179,16 +179,16 @@ public class DKIMVerifier extends DKIMCommon {
         }
         if (key == null) {
             if (lastTempFailure != null) {
-                if (sign != null) lastTempFailure.setRelatedRecordIdentity(sign.getIdentity().toString());
+                if (sign != null) lastTempFailure.setRelatedRecord(sign);
                 throw lastTempFailure;
             } else if (lastPermFailure != null) {
-                if (sign != null) lastPermFailure.setRelatedRecordIdentity(sign.getIdentity().toString());
+                if (sign != null) lastPermFailure.setRelatedRecord(sign);
                 throw lastPermFailure;
             }            // this is unexpected because the publicKeySelector always returns
             // null or exception
             else {
                 throw new PermFailException(
-                        "no key for signature [unexpected condition]", sign.getIdentity().toString());
+                        "no key for signature [unexpected condition]", sign);
             }
         }
         return key;
@@ -482,7 +482,7 @@ public class DKIMVerifier extends DKIMCommon {
             signatureCheck(h, sign, headers, signature);
 
             if (!signature.verify(decoded))
-                throw new PermFailException("Header signature does not verify");
+                throw new PermFailException("Header signature does not verify", sign);
         } catch (InvalidKeyException e) {
             throw new PermFailException(e.getMessage(), e);
         } catch (NoSuchAlgorithmException e) {

--- a/main/src/main/java/org/apache/james/jdkim/exceptions/FailException.java
+++ b/main/src/main/java/org/apache/james/jdkim/exceptions/FailException.java
@@ -19,11 +19,13 @@
 
 package org.apache.james.jdkim.exceptions;
 
+import org.apache.james.jdkim.api.SignatureRecord;
+
 public class FailException extends Exception {
 
     private static final long serialVersionUID = 1584103235607992818L;
 
-    private String relatedRecordIdentity = null;
+    private SignatureRecord relatedRecord = null;
 
     public FailException(String error) {
         super(error);
@@ -34,10 +36,17 @@ public class FailException extends Exception {
     }
 
     public String getRelatedRecordIdentity() {
-        return relatedRecordIdentity;
+        if(relatedRecord != null) {
+            return relatedRecord.getIdentity().toString();
+        }
+        return null;
     }
 
-    public void setRelatedRecordIdentity(String relatedRecordIdentity) {
-        this.relatedRecordIdentity = relatedRecordIdentity;
+    public SignatureRecord getRelatedRecord() {
+        return relatedRecord;
+    }
+
+    public void setRelatedRecord(SignatureRecord relatedRecord) {
+        this.relatedRecord = relatedRecord;
     }
 }

--- a/main/src/main/java/org/apache/james/jdkim/exceptions/PermFailException.java
+++ b/main/src/main/java/org/apache/james/jdkim/exceptions/PermFailException.java
@@ -20,6 +20,8 @@
 package org.apache.james.jdkim.exceptions;
 
 
+import org.apache.james.jdkim.api.SignatureRecord;
+
 public class PermFailException extends FailException {
 
     private static final long serialVersionUID = 1304736020453821093L;
@@ -32,9 +34,14 @@ public class PermFailException extends FailException {
         super(string, e);
     }
 
-    public PermFailException(String string, String signatureIdentity) {
+    public PermFailException(String string, SignatureRecord signatureRecord, Exception e) {
+        super(string, e);
+        setRelatedRecord(signatureRecord);
+    }
+
+    public PermFailException(String string, SignatureRecord signatureRecord) {
         super(string);
-        setRelatedRecordIdentity(signatureIdentity);
+        setRelatedRecord(signatureRecord);
     }
 
 }

--- a/main/src/main/java/org/apache/james/jdkim/impl/BodyHasherImpl.java
+++ b/main/src/main/java/org/apache/james/jdkim/impl/BodyHasherImpl.java
@@ -45,13 +45,13 @@ public class BodyHasherImpl implements BodyHasher {
             md = MessageDigest.getInstance(sign.getHashAlgo().toString());
         } catch (NoSuchAlgorithmException e) {
             throw new PermFailException("Unsupported algorythm: "
-                    + sign.getHashAlgo(), e);
+                    + sign.getHashAlgo(), sign, e);
         }
         
         try {
             sign.validate();
         } catch (IllegalStateException e) {
-            throw new PermFailException("Invalid signature template", e);
+            throw new PermFailException("Invalid signature template", sign, e);
         }
 
         int limit = sign.getBodyHashLimit();
@@ -65,7 +65,7 @@ public class BodyHasherImpl implements BodyHasher {
                         .getBodyCanonicalisationMethod())) {
             throw new PermFailException(
                     "Unsupported body canonicalization method: "
-                            + sign.getBodyCanonicalisationMethod());
+                            + sign.getBodyCanonicalisationMethod(), sign);
         }
 
         DigestOutputStream dout = new DigestOutputStream(md);


### PR DESCRIPTION
With this change is possible to use other fields like selector to generate authentication results header.

I kept getRelatedRecordIdentity to avoid breaking current users.