### PR TITLE
Add a list of results to verifier

### DIFF
--- a/main/src/main/java/org/apache/james/jdkim/api/Result.java
+++ b/main/src/main/java/org/apache/james/jdkim/api/Result.java
@@ -1,0 +1,187 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jdkim.api;
+
+/**
+ * Class to hold results of DKIMVerifier
+ */
+public class Result {
+    private final String errorMessage;
+    private final String dkimRawField;
+    private final SignatureRecord record;
+    private final Type type;
+
+    /**
+     * Result type
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc8601#section-2.7.1">RFC8601 2.7.1</a>
+     */
+    public enum Type {
+        NONE,
+        PASS,
+        FAIL,
+        POLICY,
+        NEUTRAL,
+        TEMPERROR,
+        PERMERROR
+    }
+
+    /**
+     * Constructor to create a Result instance with error message
+     *
+     * @param errorMessage Error message, from exception
+     * @param dkimRawField The DKIM-Signature field
+     * @param record       SignatureRecord
+     * @param type         Result type
+     */
+    public Result(String errorMessage, String dkimRawField, SignatureRecord record, Type type) {
+        this.errorMessage = errorMessage;
+        this.dkimRawField = dkimRawField;
+        this.record = record;
+        this.type = type;
+    }
+
+    /**
+     * Constructor to create a Result instance of a successful verification
+     *
+     * @param record SignatureRecord
+     */
+    public Result(SignatureRecord record) {
+        this.errorMessage = null;
+        this.dkimRawField = null;
+        this.record = record;
+        this.type = Type.PASS;
+    }
+
+    /**
+     * Returns a string representing the result, with a reason field
+     */
+    public String getHeaderTextWithReason() {
+        return getHeaderText(true);
+    }
+
+    /**
+     * Returns a string representing the result
+     */
+    public String getHeaderText() {
+        return getHeaderText(false);
+    }
+
+    /**
+     * Returns the header text for usage with authentication results header, like defined in RFC7601
+     *
+     * @param withReason If true, add reason field with error/success message
+     * @return String
+     */
+    private String getHeaderText(boolean withReason) {
+        if (record == null) {
+            return "";
+        }
+
+        String partialSig = "";
+        String reasonProp = "";
+        if (record.getRawSignature() != null) {
+            if (record.getRawSignature().length() >= 12) {
+                partialSig = " header.b=" + record.getRawSignature().subSequence(0, 12);
+            } else {
+                partialSig = " header.b=" + record.getRawSignature();
+            }
+        }
+
+        if (withReason) {
+            String reasonMsg;
+            switch (type) {
+                case PASS:
+                    reasonMsg = "valid signature";
+                    break;
+                case NONE:
+                    reasonMsg = "not signed";
+                    break;
+                default:
+                    reasonMsg = errorMessage != null ? errorMessage : "";
+                    break;
+            }
+            reasonProp = reasonMsg.isEmpty() ? "" : String.format(" reason=\"%s\"", reasonMsg);
+        }
+
+        return String.format("dkim=%s header.d=%s header.s=%s%s%s",
+                type.toString().toLowerCase(), record.getDToken(), record.getSelector(), partialSig, reasonProp);
+    }
+
+    /**
+     * Get ErrorMessage
+     *
+     * @return The error message produced when the exception was thrown
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /**
+     * Get dkim field
+     *
+     * @return The DKIM-Signature field that was verified
+     */
+    public String getDkimRawField() {
+        return dkimRawField;
+    }
+
+    /**
+     * @return Returns true if success
+     */
+    public boolean isSuccess() {
+        return type == Type.PASS || type == Type.NONE || type == Type.NEUTRAL;
+    }
+
+    /**
+     * @return Returns true if fail
+     */
+    public boolean isFail() {
+        return !isSuccess();
+    }
+
+    /**
+     * The resulting SignatureRecord
+     *
+     * @return SignatureRecord
+     */
+    public SignatureRecord getRecord() {
+        return record;
+    }
+
+    /**
+     * Result Type
+     *
+     * @return The result type
+     */
+    public Type getResultType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "Result{" +
+                "headerText='" + getHeaderText() + '\'' +
+                ", errorMessage='" + errorMessage + '\'' +
+                ", dkimRawField='" + dkimRawField + '\'' +
+                ", type=" + type +
+                '}';
+    }
+}

--- a/main/src/main/java/org/apache/james/jdkim/api/SignatureRecord.java
+++ b/main/src/main/java/org/apache/james/jdkim/api/SignatureRecord.java
@@ -60,6 +60,8 @@ public interface SignatureRecord {
     public abstract void validate();
 
     public abstract byte[] getSignature();
+
+    public abstract CharSequence getRawSignature();
     
     public abstract void setSignature(byte[] newSignature);
     

--- a/main/src/main/java/org/apache/james/jdkim/exceptions/CompositeFailException.java
+++ b/main/src/main/java/org/apache/james/jdkim/exceptions/CompositeFailException.java
@@ -1,0 +1,18 @@
+package org.apache.james.jdkim.exceptions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CompositeFailException extends FailException {
+    private final List<FailException> exceptions = new ArrayList<>();
+
+    public CompositeFailException(Collection<FailException> exceptions, String message) {
+        super(message);
+        this.exceptions.addAll(exceptions);
+    }
+
+    public List<FailException> getExceptions() {
+        return exceptions;
+    }
+}

--- a/main/src/main/java/org/apache/james/jdkim/tagvalue/SignatureRecordImpl.java
+++ b/main/src/main/java/org/apache/james/jdkim/tagvalue/SignatureRecordImpl.java
@@ -284,6 +284,10 @@ public class SignatureRecordImpl extends TagValue implements SignatureRecord {
         return Base64.decodeBase64(getValue("b").toString().getBytes());
     }
 
+    public CharSequence getRawSignature() {
+        return getValue("b");
+    }
+
     public int getBodyHashLimit() {
         String limit = getValue("l").toString();
         if (ALL.equals(limit))

--- a/main/src/test/java/org/apache/james/jdkim/FileBasedTest.java
+++ b/main/src/test/java/org/apache/james/jdkim/FileBasedTest.java
@@ -209,7 +209,9 @@ public class FileBasedTest extends TestCase {
                 "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC1CTqmkuRWkxlHcv1peAz3c0RuXHthVO1xx1Hy4HryZUJwSJo/R3cnEwKorQvlRuDSMgXSLLxI8u6n7h6mzRmHdsS/A+pKc7nx/6WS4N6U57PSNqOclxfwa27m/EIL6KTk9KDhaKsXxquQUBkP1CQEUZHPhQ/t7s4dmU/kvGFgNQIDAQAB");
 
         try {
-            List<SignatureRecord> res = new DKIMVerifier(pkr).verify(is);
+            DKIMVerifier verifier = new DKIMVerifier(pkr);
+            List<SignatureRecord> res = verifier.verify(is);
+            assertEquals(1, verifier.getResults().size());
             if (getName().startsWith("NONE_"))
                 assertNull(res);
             if (getName().startsWith("FAIL_"))


### PR DESCRIPTION
With this, the user can get the results of verification also when it fails partially. This commit also adds a method to return a header text representing the result.