### PR TITLE
Add DMARC compliant result method

### DIFF
--- a/main/src/main/java/org/apache/james/jdkim/DKIMVerifier.java
+++ b/main/src/main/java/org/apache/james/jdkim/DKIMVerifier.java
@@ -440,15 +440,6 @@ public class DKIMVerifier {
     }
 
     /**
-     * Returns true when all signature verification are successful. A message without dkim-signature is considered a success.
-     *
-     * @return true when success
-     */
-    public boolean isSuccess() {
-        return result.stream().allMatch(Result::isSuccess);
-    }
-
-    /**
      * Clears results list for the DKIMVerifier instance
      */
     public void resetResults() {

--- a/main/src/main/java/org/apache/james/jdkim/DKIMVerifier.java
+++ b/main/src/main/java/org/apache/james/jdkim/DKIMVerifier.java
@@ -413,12 +413,30 @@ public class DKIMVerifier {
     }
 
     /**
-     * Return the results of all signature checks, success and fail.
+     * Returns the results of all signature checks, success and fail.
+     * If a message doesn't have a DKIM-Signature header the result list will
+     * be empty. Use {@link Result#getResultType} or {@link Result#isSuccess}
+     * to get verification result of each DKIM-Signature check. Call {@link #resetResults}
+     * if the same instance of {@code DKIMVerifier} is reused for a new {@code verify} call.
      *
      * @return List of {@link Result} object.
      */
     public List<Result> getResults() {
         return result;
+    }
+
+    /**
+     * Returns {@code true} if at least one signature is successfully verified.
+     * A message pass the DKIM check when at least one signature is valid.
+     * This method is DMARC compliant, and should be called after {@code DKIMVerifier.verify}.
+     * Use {@link #getResults} to get result details.
+     *
+     * @return {@code true} if a valid signature is found,
+     * {@code false} if there's no valid signature.
+     * @see #getResults
+     */
+    public boolean hasAnyValidSignature() {
+        return result.stream().anyMatch(Result::isSuccess);
     }
 
     /**

--- a/main/src/main/java/org/apache/james/jdkim/api/Result.java
+++ b/main/src/main/java/org/apache/james/jdkim/api/Result.java
@@ -112,7 +112,7 @@ public class Result {
                     reasonMsg = "valid signature";
                     break;
                 case NONE:
-                    reasonMsg = "not signed";
+                    reasonMsg = "unknown error";
                     break;
                 default:
                     reasonMsg = errorMessage != null ? errorMessage : "";
@@ -147,7 +147,7 @@ public class Result {
      * @return Returns true if success
      */
     public boolean isSuccess() {
-        return type == Type.PASS || type == Type.NONE || type == Type.NEUTRAL;
+        return type == Type.PASS;
     }
 
     /**


### PR DESCRIPTION
A message with at least one valid signature is considered a DKIM pass, this commit adds a method to return true for any signature pass.

Sorry, I overlooked this in the previous commit.